### PR TITLE
Allow support for custom annotations to `ingress-nginx-service`

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -6,6 +6,7 @@ resource "kubernetes_service" "ingress-nginx-service" {
       "app.kubernetes.io/name"    = "ingress-nginx"
       "app.kubernetes.io/part-of" = "ingress-nginx"
     }
+    annotations = var.service_annotations
   }
 
   spec {

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,8 @@ resource_limits = {
 EOF
   default = {}
 }
+
+variable "service_annotations" {
+  description = "The annotations to set in `ingress-nginx-service`"
+  default     = {}
+}


### PR DESCRIPTION
Proposed in #5 